### PR TITLE
Embedding size impact

### DIFF
--- a/vanjari/data.py
+++ b/vanjari/data.py
@@ -71,7 +71,7 @@ class VanjariStackTrainingDataset(Dataset):
         node_id = int(seq_detail.node_id)
         del seq_detail
         
-        assert embedding.shape[-1] == 1024, f"Embedding shape restricted to 1024, here is {embedding.shape[-1]}"
+        # assert embedding.shape[-1] == 1024, f"Embedding shape restricted to 1024, here is {embedding.shape[-1]}"
         
         return embedding, node_id
 

--- a/vanjari/data.py
+++ b/vanjari/data.py
@@ -116,7 +116,7 @@ class VanjariStackDataModule(L.LightningDataModule):
         self.training = []
         self.validation = []
 
-        assert self.array.shape[-1] == 1024, f"Embedding shape restricted to 1024, here is {self.array.shape[-1]}"
+        # assert self.array.shape[-1] == 1024, f"Embedding shape restricted to 1024, here is {self.array.shape[-1]}"
 
         random.seed(self.seed)
 

--- a/vanjari/models.py
+++ b/vanjari/models.py
@@ -42,7 +42,7 @@ class VanjariAttentionModel(nn.Module):
             x = x.to(dtype=self.model_dtype)
 
         # Hack for sanity
-        assert x.shape[-1] == 1024
+        # assert x.shape[-1] == 1024
 
         x = self.sequential(x)
 


### PR DESCRIPTION
Hi Rob,

I found that when using my own trained nt v2 model (250m), the scaling causes it to have embedding size of 768 rather than 1024. Could you relax that setting so when running porphyra I don't need to go to the site-packages directory to edit it?

Cheers
Andy